### PR TITLE
chore: move env-logger into deps

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+env_logger = "0.7"
 log = "0.4"
 serde = "1.0"
 serde_json = "1.0"
@@ -26,9 +27,6 @@ default = []
 redis-ratelimiter = [
 	"redis",
 ]
-
-[dev-dependencies]
-env_logger = "0.7"
 
 [dev-dependencies.tokio]
 version = "0.2"


### PR DESCRIPTION
This PR moves env-logger of `core` into the dependencies field. This happens because come compile time, the debug macro isn't found and it fails to compile.   

Imported with:
```toml
proxy = { git = "https://github.com/spec-tacles/proxy", package = "spectacles-proxy" }
```  

Error at compile time:
```rs
    Checking spectacles-proxy v0.1.0 (https://github.com/spec-tacles/proxy#fa23c364)
error: cannot find macro `debug` in this scope
  --> /Users/carterhimmel/.cargo/git/checkouts/proxy-5563f4ff4dc11da4/fa23c36/core/src/ratelimiter/local.rs:52:4
   |
52 |             debug!("Acquired lock for \"{}\"", &bucket_name);
   |             ^^^^^
```