### PR TITLE
ci: cache build assets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
   release:
     types: [ published ]
 
@@ -20,6 +18,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: rustup default nightly
+    - name: Checkout build cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-check-${{ matrix.runtime }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --release --verbose -Z unstable-options --out-dir ./out
     - name: Compress output


### PR DESCRIPTION
This PR adds the checking out and saving of build cache. Taken from [the actions/cache examples](https://github.com/actions/cache/blob/main/examples.md#rust---cargo).